### PR TITLE
COMP: Specify GTest install lib directory

### DIFF
--- a/SuperBuild/External_GTest.cmake
+++ b/SuperBuild/External_GTest.cmake
@@ -57,6 +57,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
       -DGTest_INSTALL_RUNTIME_DIR:STRING=${Slicer_INSTALL_THIRDPARTY_LIB_DIR}
       -DGTest_INSTALL_LIBRARY_DIR:STRING=${Slicer_INSTALL_THIRDPARTY_LIB_DIR}
       -DCMAKE_INSTALL_PREFIX:PATH=${EP_BINARY_DIR}/install
+      -DCMAKE_INSTALL_LIBDIR:PATH=lib # Skip default initialization by GNUInstallDirs CMake module
       -DBUILD_TESTING:BOOL=OFF
       # For Windows: Prevent overriding the parent project's compiler/linker settings
       -Dgtest_force_shared_crt=ON


### PR DESCRIPTION
Previously, lib was assumed for CMAKE_INSTALL_LIBDIR, which caused
issues on some builds where GNUInstallDirs defaulted
CMAKE_INSTALL_LIBDIR to lib64.